### PR TITLE
Fix preg_replace error for heavy compression

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -143,7 +143,7 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements \Phile\Gateway\Even
                 $html = preg_replace('/<!--[^(\[|(<!))](.*)-->/Uis', '', $html);
 
                 // Replace all whitespace characters with a single space
-                $html = preg_replace(">`\s+`<", "> <", $html);
+                $html = preg_replace("`\s+`", " ", $html);
 
                 // Remove the spaces between adjacent html tags
                 $html = preg_replace("`> <`", "><", $html);


### PR DESCRIPTION
Gave error: preg_replace(): No ending delimiter '&gt;' found

Not sure what the intended behavior is in this case, but I went by what the comment said.
